### PR TITLE
Remove usage of StyleablePart

### DIFF
--- a/charts_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/charts/pie/view/PieChartPluginPart.kt
+++ b/charts_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/charts/pie/view/PieChartPluginPart.kt
@@ -8,21 +8,13 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.View
 import android.widget.FrameLayout
-import com.futureworkshops.mobileworkflow.SurveyTheme
-import com.futureworkshops.mobileworkflow.backend.views.main_parts.StyleablePart
 import com.futureworkshops.mobileworkflow.plugin.charts.R
 
 internal class PieChartPluginPart @JvmOverloads constructor(
     context: Context,
-    private val styleListener: StyleListener,
     attrs: AttributeSet? = null,
     defStyleRes: Int = 0
-) : FrameLayout(context, attrs, defStyleRes), StyleablePart {
+) : FrameLayout(context, attrs, defStyleRes) {
 
     val view: View = View.inflate(context, R.layout.pie_chart_plugin_step, this)
-
-    override fun style(surveyTheme: SurveyTheme) {
-        styleListener.onTintColorReady(surveyTheme.themeColor)
-    }
-
 }

--- a/charts_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/charts/pie/view/PieChartPluginView.kt
+++ b/charts_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/charts/pie/view/PieChartPluginView.kt
@@ -21,8 +21,7 @@ import com.mattyork.colours.Colour
 internal class PieChartPluginView(
     fragmentStepConfiguration: FragmentStepConfiguration,
     val itemsProvider: ItemsProvider
-) : FragmentStep(fragmentStepConfiguration),
-    StyleListener {
+) : FragmentStep(fragmentStepConfiguration) {
 
     private lateinit var pieChartPluginPart: PieChartPluginPart
 
@@ -33,13 +32,9 @@ internal class PieChartPluginView(
     override fun setupViews() {
         super.setupViews()
         context?.let { safeContext ->
-            pieChartPluginPart = PieChartPluginPart(safeContext, this)
+            pieChartPluginPart = PieChartPluginPart(safeContext)
             content.add(pieChartPluginPart)
         }
-    }
-
-    override fun onTintColorReady(color: Int) {
-        itemsProvider.onItemsReady { setupPie(it) }
     }
 
     private fun setupPie(items: List<PieChartItem>) {
@@ -71,10 +66,4 @@ internal class PieChartPluginView(
             invalidate()
         }
     }
-}
-
-internal interface StyleListener {
-
-    fun onTintColorReady(color: Int)
-
 }


### PR DESCRIPTION
### Checklist

- [x] I've validated if any R8 rule should be added to the relevant proguard-rules.pro file. More info about it [on Confluence](https://futureworkshops.atlassian.net/wiki/spaces/FMW/pages/2319187983/Validate+R8+rules+for+core+and+plugins)
- [X] If I'm updating a plugin submodule, I'm sure that the reference on the submodule is on `main`

### Task

[Remove usage of StyleablePart](https://3.basecamp.com/5245563/buckets/26795773/todos/4780099243)

### Feature/Issue

Currently many steps use StyleablePart interface to receive the themeSurvey and extract the tint color from it. This interface should be removed from the code base, as each steps should use the theme of the app.

### Implementation

Remove the use of StyleablePart, and move any needed code from the interface implementation to another part of the step's code.